### PR TITLE
make Makefile compatible with dash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ getscancodes: getscancodes.c
 key_names.inc: SCRIPT='$$v = int($$3)||oct($$3), printf(qq|  { %s, "%s" }, // %d 0x%x\n|, \
 	$$1, $$2, $$v, $$v) if m/^\#define (KEY_(\w+))\s+(\d\S*)/'
 key_names.inc: Makefile
-	gcc -xc -E -dM - <<< '#include <linux/input.h>' |\
+	echo '#include <linux/input.h>' | gcc -xc -E -dM - |\
 	perl -ne $(SCRIPT) |sort -k6n >$@
 
 evmap.o: key_names.inc


### PR DESCRIPTION
Many systems (in particular Debian & Ubuntu) symlink `/bin/sh` to `dash`, which does not have the ["here-string"](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Here-Strings) redirection operator `<<<`. This PR replaces it with a regular echo which should work everywhere.